### PR TITLE
Completed JSON loot tables for meteorites.

### DIFF
--- a/src/main/java/appeng/core/AEJSONConfig.java
+++ b/src/main/java/appeng/core/AEJSONConfig.java
@@ -53,13 +53,34 @@ public class AEJSONConfig{
 
     public static AEJSONConfig createDefaultConfig() {
         AEJSONConfig config = new AEJSONConfig();
-        AEJSONEntry calcProcessorPress;
-        AEJSONEntry engProcessorPress ;
-        AEJSONEntry logicProcessorPress;
-        AEJSONEntry siliconPress;
-        AEJSONEntry goldNugget = new AEJSONEntry("minecraft:gold_nugget", 0, 0, 12, 1, -1);
+        AEJSONEntry calcProcessorPress = new AEJSONEntry("appliedenergistics2:item.ItemMultiMaterial", 13, 0, 1, 1, 1);
+        AEJSONEntry engProcessorPress = new AEJSONEntry("appliedenergistics2:item.ItemMultiMaterial", 14, 0, 1, 1, 1);
+        AEJSONEntry logicProcessorPress = new AEJSONEntry("appliedenergistics2:item.ItemMultiMaterial", 15, 0, 1, 1, 1);
+        AEJSONEntry siliconPress = new AEJSONEntry("appliedenergistics2:item.ItemMultiMaterial", 19, 0, 1, 1, 1);
 
-        config.dimension_loot_tables.put("0", Arrays.asList(Arrays.asList(goldNugget)));
+        AEJSONEntry IronNugget = new AEJSONEntry("ore:nuggetIron", 0, 0, 12, 1, -1);
+        AEJSONEntry CopperNugget = new AEJSONEntry("ore:nuggetCopper", 0, 0, 12, 1, 3);
+        AEJSONEntry TinNugget = new AEJSONEntry("ore:nuggetTin", 0, 0, 12, 1, 4);
+        AEJSONEntry SilverNugget = new AEJSONEntry("ore:nuggetSilver", 0, 0, 12, 1, 5);
+        AEJSONEntry LeadNugget = new AEJSONEntry("ore:nuggetLead", 0, 0, 12, 1, 2);
+        AEJSONEntry PlatinumNugget = new AEJSONEntry("ore:nuggetPlatinum", 0, 0, 12, 1, 3);
+        AEJSONEntry NickelNugget = new AEJSONEntry("ore:nuggetNickel", 0, 0, 12, 1, 4);
+        AEJSONEntry AluminiumNugget = new AEJSONEntry("ore:nuggetAluminium", 0, 0, 12, 1, 5);
+        AEJSONEntry ElectrumNugget = new AEJSONEntry("ore:nuggetElectrum", 0, 0, 12, 1, 2);
+        AEJSONEntry GoldNugget = new AEJSONEntry("minecraft:gold_nugget", 0, 0, 12, 1, -1);
+        AEJSONEntry Diamond = new AEJSONEntry("minecraft:diamond", 0, 2, 4, 1, 1);
+        config.dimension_loot_tables.put("0", Arrays.asList(
+                Arrays.asList(calcProcessorPress, CopperNugget, PlatinumNugget, IronNugget, GoldNugget),
+                Arrays.asList(engProcessorPress, TinNugget, NickelNugget, IronNugget, GoldNugget),
+                Arrays.asList(logicProcessorPress, SilverNugget, AluminiumNugget, IronNugget, GoldNugget),
+                Arrays.asList(siliconPress, LeadNugget, ElectrumNugget, IronNugget, GoldNugget)
+                                                            ));
+        config.dimension_loot_tables.put("-29", Arrays.asList(
+                Arrays.asList(calcProcessorPress, CopperNugget, PlatinumNugget, IronNugget, GoldNugget, Diamond),
+                Arrays.asList(engProcessorPress, TinNugget, NickelNugget, IronNugget, GoldNugget, Diamond),
+                Arrays.asList(logicProcessorPress, SilverNugget, AluminiumNugget, IronNugget, GoldNugget, Diamond),
+                Arrays.asList(siliconPress, LeadNugget, ElectrumNugget, IronNugget, GoldNugget, Diamond)
+        ));
         return config;
     }
 
@@ -67,11 +88,14 @@ public class AEJSONConfig{
 
 
 
-    public List<List<AEJSONEntry>> getTablesForDimension(int dimensionID)
+    private List<List<AEJSONEntry>> getTablesForDimension(int dimensionID)
     {
         if(DimensionManager.isDimensionRegistered(dimensionID)) {
             if(dimension_loot_tables.containsKey(dimensionID+"")) {
                 return dimension_loot_tables.get(dimensionID+"");
+            }
+            else if (dimension_loot_tables.containsKey("0")) {
+                return dimension_loot_tables.get("0");
             }
             else {
                 return createDefaultConfig().getTablesForDimension(0);

--- a/src/main/java/appeng/core/AEJSONConfig.java
+++ b/src/main/java/appeng/core/AEJSONConfig.java
@@ -15,7 +15,81 @@ import java.util.Random;
 
 public class AEJSONConfig{
     public static AEJSONConfig instance;
-    //Conbined weight of items in List<AEJSONEntry>[] is that loottable's weight when selecting a loot table for dimension
+    /**
+     * Parameters:
+     * item:  TYPE: STRING  DEFAULT VALUE:  NONE. PARAMETER IS REQUIRED  DESCRIPTION: The name of the item as used by the /give command  EXAMPLE: "minecraft:dirt"
+     * meta_data:  TYPE: NON-NEGATIVE INTEGER  DEFAULT VALUE:  0  DESCRIPTION: Metadata value for the item, the 3rd parameter in the /give command  EXAMPLE: 3
+     * min_value:  TYPE: NON-NEGATIVE INTEGER  DEFAULT VALUE:  0  DESCRIPTION: The minimum amount of that item that is inserted when that item is selected (SETTING TO 1 DOES NOT GUARANTEE THAT ITEM IN EVERY CHEST)  EXAMPLE: 4
+     * max_value:  TYPE: NON-NEGATIVE INTEGER  DEFAULT VALUE:  1  DESCRIPTION: The maximum amount of that item that is inserted when that item is selected  EXAMPLE: 72
+     * weight:  TYPE: NON-NEGATIVE INTEGER  DEFAULT VALUE:  1  DESCRIPTION:  The weighted chance the item is chosen. (Weights are compared between entries with the same exclusive group)  EXAMPLE: 40
+     * exclusiveGroupID:  TYPE: INTEGER  DEFAULT VALUE:  -1  DESCRIPTION:  exclusiveGroupID lets you group entries so only one from the group can appear, chosen based on weight. If multiple entries share the same group ID, only one will be picked. If an entry is the only one in its group, it's guaranteed to appear. Setting this parameter to -1 will cause it to ignore exclusivity  EXAMPLE: 154
+     *
+     * Notes:
+     * The Key Value:  For the dimension_loot_tables a key value is required, this value represents the dimensionID for the loot tables. For example, -29 is Galacticraft Mars, the loot tables under that id will only spawn in that dimension (if meteorites spawn there)
+     * The list of loot tables:  The chance of a loot table within a dimension being selected is weighted by the total weight of every entry in that loot table against every other loot tables' total weights
+     * Format:  {
+     *   "dimension_loot_tables": {
+     *     "0": [   This is the start of a list of loot tables
+     *       [    this is the start of a loot table
+     *         {
+     *             ENTRY
+     *         },
+     *         {
+     *             ANOTHER ENTRY
+     *         }
+     *       ],   this is the end of a loot table
+     *       [    this is the start of another separate loot table
+     *         {
+     *             ENTRY
+     *         },
+     *         {
+     *             ANOTHER ENTRY
+     *         }
+     *       ]    this is the end of a loot table
+     *    ], this is the end of the list of loot tables
+     *    "-29": [   this is the start of a list of loot tables for another dimension, and so on
+     *       [
+     *         {
+     * }
+     */
+    @SerializedName("Info and Tips:")
+    private final String[] notes = {"Parameters:",
+            "item:  TYPE: STRING  DEFAULT VALUE:  NONE. PARAMETER IS REQUIRED  DESCRIPTION: The name of the item as used by the /give command  EXAMPLE: \"minecraft:dirt\"",
+            "meta_data:  TYPE: NON-NEGATIVE INTEGER  DEFAULT VALUE:  0  DESCRIPTION: Metadata value for the item, the 3rd parameter in the /give command  EXAMPLE: 3",
+            "min_value:  TYPE: NON-NEGATIVE INTEGER  DEFAULT VALUE:  0  DESCRIPTION: The minimum amount of that item that is inserted when that item is selected (SETTING TO 1 DOES NOT GUARANTEE THAT ITEM IN EVERY CHEST)  EXAMPLE: 4",
+            "max_value:  TYPE: NON-NEGATIVE INTEGER  DEFAULT VALUE:  1  DESCRIPTION: The maximum amount of that item that is inserted when that item is selected  EXAMPLE: 72",
+            "weight:  TYPE: NON-NEGATIVE INTEGER  DEFAULT VALUE:  1  DESCRIPTION:  The weighted chance the item is chosen. (Weights are compared between entries with the same exclusive group)  EXAMPLE: 40",
+            "exclusiveGroupID:  TYPE: INTEGER  DEFAULT VALUE:  -1  DESCRIPTION:  exclusiveGroupID lets you group entries so only one from the group can appear, chosen based on weight. If multiple entries share the same group ID, only one will be picked. If an entry is the only one in its group, its guaranteed to appear. Setting this parameter to -1 will cause it to ignore exclusivity  EXAMPLE: 154",
+            "",
+            "Notes:",
+            "The Key Value:  For the dimension_loot_tables a key value is required, this value represents the dimensionID for the loot tables. For example, -29 is Galacticraft Mars, the loot tables under that id will only spawn in that dimension (if meteorites spawn there)",
+            "The list of loot tables:  The chance of a loot table within a dimension being selected is weighted by the total weight of every entry in that loot table against every other loot tables total weights",
+            "Format:  {",
+            "      \"dimension_loot_tables\": {",
+                    "   \"0\": [   This is the start of a list of loot tables",
+                    "       [    this is the start of a loot table,",
+                    "         {",
+                    "             ENTRY",
+                    "         },",
+                    "         {",
+                    "             ANOTHER ENTRY",
+                    "         }",
+                    "       ],   this is the end of a loot table",
+                    "       [    this is the start of another separate loot table",
+                    "         {",
+                    "             ENTRY",
+                    "         },",
+                    "         {",
+                    "             ANOTHER ENTRY",
+                    "         }",
+                    "       ]    this is the end of a loot table",
+                    "    ], this is the end of the list of loot tables",
+                    "    \"-29\": [   this is the start of a list of loot tables for another dimension, and so on",
+                    "       [",
+                    "         {",
+                    " }"
+
+    };
     @SerializedName("dimension_loot_tables")
     private Map<String, ArrayList<ArrayList<AEJSONEntry>>> dimension_loot_tables = new HashMap<>();
 
@@ -53,33 +127,34 @@ public class AEJSONConfig{
 
     public static AEJSONConfig createDefaultConfig() {
         AEJSONConfig config = new AEJSONConfig();
-        AEJSONEntry calcProcessorPress = new AEJSONEntry("appliedenergistics2:item.ItemMultiMaterial", 13, 0, 1, 1, 1);
-        AEJSONEntry engProcessorPress = new AEJSONEntry("appliedenergistics2:item.ItemMultiMaterial", 14, 0, 1, 1, 1);
-        AEJSONEntry logicProcessorPress = new AEJSONEntry("appliedenergistics2:item.ItemMultiMaterial", 15, 0, 1, 1, 1);
-        AEJSONEntry siliconPress = new AEJSONEntry("appliedenergistics2:item.ItemMultiMaterial", 19, 0, 1, 1, 1);
+        AEJSONEntry calcProcessorPress = new AEJSONEntry("appliedenergistics2:item.ItemMultiMaterial", 13, 1, null, 3, 1);
+        AEJSONEntry engProcessorPress = new AEJSONEntry("appliedenergistics2:item.ItemMultiMaterial", 14, 1, null, 3, 1);
+        AEJSONEntry logicProcessorPress = new AEJSONEntry("appliedenergistics2:item.ItemMultiMaterial", 15, 1, null, 3, 1);
+        AEJSONEntry siliconPress = new AEJSONEntry("appliedenergistics2:item.ItemMultiMaterial", 19, 1, null, 3, 1);
 
-        AEJSONEntry IronNugget = new AEJSONEntry("ore:nuggetIron", 0, 0, 12, 1, -1);
-        AEJSONEntry CopperNugget = new AEJSONEntry("ore:nuggetCopper", 0, 0, 12, 1, 3);
-        AEJSONEntry TinNugget = new AEJSONEntry("ore:nuggetTin", 0, 0, 12, 1, 4);
-        AEJSONEntry SilverNugget = new AEJSONEntry("ore:nuggetSilver", 0, 0, 12, 1, 5);
-        AEJSONEntry LeadNugget = new AEJSONEntry("ore:nuggetLead", 0, 0, 12, 1, 2);
-        AEJSONEntry PlatinumNugget = new AEJSONEntry("ore:nuggetPlatinum", 0, 0, 12, 1, 3);
-        AEJSONEntry NickelNugget = new AEJSONEntry("ore:nuggetNickel", 0, 0, 12, 1, 4);
-        AEJSONEntry AluminiumNugget = new AEJSONEntry("ore:nuggetAluminium", 0, 0, 12, 1, 5);
-        AEJSONEntry ElectrumNugget = new AEJSONEntry("ore:nuggetElectrum", 0, 0, 12, 1, 2);
-        AEJSONEntry GoldNugget = new AEJSONEntry("minecraft:gold_nugget", 0, 0, 12, 1, -1);
-        AEJSONEntry Diamond = new AEJSONEntry("minecraft:diamond", 0, 2, 4, 1, 1);
+        AEJSONEntry IronNugget = new AEJSONEntry("ore:nuggetIron", null, 1, 12, 3, null);
+        AEJSONEntry CopperNugget = new AEJSONEntry("ore:nuggetCopper", null, 1, 12, 3, 3);
+        AEJSONEntry TinNugget = new AEJSONEntry("ore:nuggetTin", null, 1, 12, 3, 4);
+        AEJSONEntry SilverNugget = new AEJSONEntry("ore:nuggetSilver", null, 1, 12, 3, 5);
+        AEJSONEntry LeadNugget = new AEJSONEntry("ore:nuggetLead", null, 1, 12, 3, 2);
+        AEJSONEntry PlatinumNugget = new AEJSONEntry("ore:nuggetPlatinum", null, 1, 12, 3, 3);
+        AEJSONEntry NickelNugget = new AEJSONEntry("ore:nuggetNickel", null, 1, 12, 3, 4);
+        AEJSONEntry AluminiumNugget = new AEJSONEntry("ore:nuggetAluminium", null, 1, 12, 3, 5);
+        AEJSONEntry ElectrumNugget = new AEJSONEntry("ore:nuggetElectrum", null, 1, 12, 3, 2);
+        AEJSONEntry GoldNugget = new AEJSONEntry("minecraft:gold_nugget", null, 1, 12, 3, null);
+        AEJSONEntry Skystone = new AEJSONEntry("appliedenergistics2:tile.BlockSkyStone", null, null, 12, null, null);
+        AEJSONEntry Diamond = new AEJSONEntry("minecraft:diamond", null, 2, 4, null, null);
         config.dimension_loot_tables.put("0", new ArrayList<>(Arrays.asList(
-                new ArrayList<>(Arrays.asList(calcProcessorPress, CopperNugget, PlatinumNugget, IronNugget, GoldNugget)),
-                new ArrayList<>(Arrays.asList(engProcessorPress, TinNugget, NickelNugget, IronNugget, GoldNugget)),
-                new ArrayList<>(Arrays.asList(logicProcessorPress, SilverNugget, AluminiumNugget, IronNugget, GoldNugget)),
-                new ArrayList<>(Arrays.asList(siliconPress, LeadNugget, ElectrumNugget, IronNugget, GoldNugget))
+                new ArrayList<>(Arrays.asList(calcProcessorPress, CopperNugget, PlatinumNugget, IronNugget, GoldNugget, Skystone)),
+                new ArrayList<>(Arrays.asList(engProcessorPress, TinNugget, NickelNugget, IronNugget, GoldNugget, Skystone)),
+                new ArrayList<>(Arrays.asList(logicProcessorPress, SilverNugget, AluminiumNugget, IronNugget, GoldNugget, Skystone)),
+                new ArrayList<>(Arrays.asList(siliconPress, LeadNugget, ElectrumNugget, IronNugget, GoldNugget, Skystone))
         )));
         config.dimension_loot_tables.put("-29", new ArrayList<>(Arrays.asList(
-                new ArrayList<>(Arrays.asList(calcProcessorPress, CopperNugget, PlatinumNugget, IronNugget, GoldNugget, Diamond)),
-                new ArrayList<>(Arrays.asList(engProcessorPress, TinNugget, NickelNugget, IronNugget, GoldNugget, Diamond)),
-                new ArrayList<>(Arrays.asList(logicProcessorPress, SilverNugget, AluminiumNugget, IronNugget, GoldNugget, Diamond)),
-                new ArrayList<>(Arrays.asList(siliconPress, LeadNugget, ElectrumNugget, IronNugget, GoldNugget, Diamond))
+                new ArrayList<>(Arrays.asList(calcProcessorPress, CopperNugget, PlatinumNugget, IronNugget, GoldNugget, Skystone, Diamond)),
+                new ArrayList<>(Arrays.asList(engProcessorPress, TinNugget, NickelNugget, IronNugget, GoldNugget, Skystone, Diamond)),
+                new ArrayList<>(Arrays.asList(logicProcessorPress, SilverNugget, AluminiumNugget, IronNugget, GoldNugget, Skystone, Diamond)),
+                new ArrayList<>(Arrays.asList(siliconPress, LeadNugget, ElectrumNugget, IronNugget, GoldNugget, Skystone, Diamond))
         )));
         return config;
     }
@@ -98,7 +173,7 @@ public class AEJSONConfig{
             }
         }
         else {
-            System.err.println("AE2: Failure While Getting Loot Tables for Dimension: " + dimensionID + " | Error: Dimension is not registered");
+            System.err.println("AE2: Failure While Getting Loot Tables for Dimension: " + dimensionID + ". Using overworld configs. | Error: Dimension is not registered");
             return dimension_loot_tables.get("0");
         }
     }
@@ -120,16 +195,10 @@ public class AEJSONConfig{
 
         int randomWeight = rand.nextInt(totalWeight);
         int cumulitive = 0;
-        //System.out.println("AE2: Loot_tables: " + loot_tables);
         for(int i = 0; i < totalWeights.length; i++) {
             cumulitive+=totalWeights[i];
-            System.out.println("AE2: Comparing " + randomWeight + " <= " + cumulitive + "for index " + i + " result: " + (randomWeight <= cumulitive));
             if(randomWeight <= cumulitive) {
-                System.out.println("AE2: Attempting to find loot_table at index " + i);
-                System.out.print("AE2: Found! Returning loot_table: ");
-                //System.out.println(loot_tables.get(i));
                 return loot_tables.get(i);
-                //return Arrays.asList(new AEJSONEntry("minecraft:nether_star", 0, 4, 4, 1, 100));
             }
         }
         System.err.println("AE2: Failed to pull a weighted random loot_table for dimension: " + dimID + ", pulling unweighted random loot_table. | Error: Weighted random failed. THIS IS LIKELY A BUG.");

--- a/src/main/java/appeng/core/AEJSONConfig.java
+++ b/src/main/java/appeng/core/AEJSONConfig.java
@@ -1,114 +1,85 @@
 package appeng.core;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.annotations.SerializedName;
-import net.minecraftforge.common.DimensionManager;
-import org.apache.commons.io.FileUtils;
 import java.io.File;
 import java.nio.charset.Charset;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.ArrayList;
 import java.util.Map;
 import java.util.Random;
 
-public class AEJSONConfig{
+import net.minecraftforge.common.DimensionManager;
+
+import org.apache.commons.io.FileUtils;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.annotations.SerializedName;
+
+public class AEJSONConfig {
+
     public static AEJSONConfig instance;
     /**
-     * Parameters:
-     * item:  TYPE: STRING  DEFAULT VALUE:  NONE. PARAMETER IS REQUIRED  DESCRIPTION: The name of the item as used by the /give command  EXAMPLE: "minecraft:dirt"
-     * meta_data:  TYPE: NON-NEGATIVE INTEGER  DEFAULT VALUE:  0  DESCRIPTION: Metadata value for the item, the 3rd parameter in the /give command  EXAMPLE: 3
-     * min_value:  TYPE: NON-NEGATIVE INTEGER  DEFAULT VALUE:  0  DESCRIPTION: The minimum amount of that item that is inserted when that item is selected (SETTING TO 1 DOES NOT GUARANTEE THAT ITEM IN EVERY CHEST)  EXAMPLE: 4
-     * max_value:  TYPE: NON-NEGATIVE INTEGER  DEFAULT VALUE:  1  DESCRIPTION: The maximum amount of that item that is inserted when that item is selected  EXAMPLE: 72
-     * weight:  TYPE: NON-NEGATIVE INTEGER  DEFAULT VALUE:  1  DESCRIPTION:  The weighted chance the item is chosen. (Weights are compared between entries with the same exclusive group)  EXAMPLE: 40
-     * exclusiveGroupID:  TYPE: INTEGER  DEFAULT VALUE:  -1  DESCRIPTION:  exclusiveGroupID lets you group entries so only one from the group can appear, chosen based on weight. If multiple entries share the same group ID, only one will be picked. If an entry is the only one in its group, it's guaranteed to appear. Setting this parameter to -1 will cause it to ignore exclusivity  EXAMPLE: 154
+     * Parameters: item: TYPE: STRING DEFAULT VALUE: NONE. PARAMETER IS REQUIRED DESCRIPTION: The name of the item as
+     * used by the /give command EXAMPLE: "minecraft:dirt" meta_data: TYPE: NON-NEGATIVE INTEGER DEFAULT VALUE: 0
+     * DESCRIPTION: Metadata value for the item, the 3rd parameter in the /give command EXAMPLE: 3 min_value: TYPE:
+     * NON-NEGATIVE INTEGER DEFAULT VALUE: 0 DESCRIPTION: The minimum amount of that item that is inserted when that
+     * item is selected (SETTING TO 1 DOES NOT GUARANTEE THAT ITEM IN EVERY CHEST) EXAMPLE: 4 max_value: TYPE:
+     * NON-NEGATIVE INTEGER DEFAULT VALUE: 1 DESCRIPTION: The maximum amount of that item that is inserted when that
+     * item is selected EXAMPLE: 72 weight: TYPE: NON-NEGATIVE INTEGER DEFAULT VALUE: 1 DESCRIPTION: The weighted chance
+     * the item is chosen. (Weights are compared between entries with the same exclusive group) EXAMPLE: 40
+     * exclusiveGroupID: TYPE: INTEGER DEFAULT VALUE: -1 DESCRIPTION: exclusiveGroupID lets you group entries so only
+     * one from the group can appear, chosen based on weight. If multiple entries share the same group ID, only one will
+     * be picked. If an entry is the only one in its group, it's guaranteed to appear. Setting this parameter to -1 will
+     * cause it to ignore exclusivity EXAMPLE: 154
      *
-     * Notes:
-     * The Key Value:  For the dimension_loot_tables a key value is required, this value represents the dimensionID for the loot tables. For example, -29 is Galacticraft Mars, the loot tables under that id will only spawn in that dimension (if meteorites spawn there)
-     * The list of loot tables:  The chance of a loot table within a dimension being selected is weighted by the total weight of every entry in that loot table against every other loot tables' total weights
-     * Format:  {
-     *   "dimension_loot_tables": {
-     *     "0": [   This is the start of a list of loot tables
-     *       [    this is the start of a loot table
-     *         {
-     *             ENTRY
-     *         },
-     *         {
-     *             ANOTHER ENTRY
-     *         }
-     *       ],   this is the end of a loot table
-     *       [    this is the start of another separate loot table
-     *         {
-     *             ENTRY
-     *         },
-     *         {
-     *             ANOTHER ENTRY
-     *         }
-     *       ]    this is the end of a loot table
-     *    ], this is the end of the list of loot tables
-     *    "-29": [   this is the start of a list of loot tables for another dimension, and so on
-     *       [
-     *         {
-     * }
+     * Notes: The Key Value: For the dimension_loot_tables a key value is required, this value represents the
+     * dimensionID for the loot tables. For example, -29 is Galacticraft Mars, the loot tables under that id will only
+     * spawn in that dimension (if meteorites spawn there) The list of loot tables: The chance of a loot table within a
+     * dimension being selected is weighted by the total weight of every entry in that loot table against every other
+     * loot tables' total weights Format: { "dimension_loot_tables": { "0": [ This is the start of a list of loot tables
+     * [ this is the start of a loot table { ENTRY }, { ANOTHER ENTRY } ], this is the end of a loot table [ this is the
+     * start of another separate loot table { ENTRY }, { ANOTHER ENTRY } ] this is the end of a loot table ], this is
+     * the end of the list of loot tables "-29": [ this is the start of a list of loot tables for another dimension, and
+     * so on [ { }
      */
     @SerializedName("Info and Tips:")
-    private final String[] notes = {"Parameters:",
+    private final String[] notes = { "Parameters:",
             "item:  TYPE: STRING  DEFAULT VALUE:  NONE. PARAMETER IS REQUIRED  DESCRIPTION: The name of the item as used by the /give command  EXAMPLE: \"minecraft:dirt\"",
             "meta_data:  TYPE: NON-NEGATIVE INTEGER  DEFAULT VALUE:  0  DESCRIPTION: Metadata value for the item, the 3rd parameter in the /give command  EXAMPLE: 3",
             "min_value:  TYPE: NON-NEGATIVE INTEGER  DEFAULT VALUE:  0  DESCRIPTION: The minimum amount of that item that is inserted when that item is selected (SETTING TO 1 DOES NOT GUARANTEE THAT ITEM IN EVERY CHEST)  EXAMPLE: 4",
             "max_value:  TYPE: NON-NEGATIVE INTEGER  DEFAULT VALUE:  1  DESCRIPTION: The maximum amount of that item that is inserted when that item is selected  EXAMPLE: 72",
             "weight:  TYPE: NON-NEGATIVE INTEGER  DEFAULT VALUE:  1  DESCRIPTION:  The weighted chance the item is chosen. (Weights are compared between entries with the same exclusive group)  EXAMPLE: 40",
             "exclusiveGroupID:  TYPE: INTEGER  DEFAULT VALUE:  -1  DESCRIPTION:  exclusiveGroupID lets you group entries so only one from the group can appear, chosen based on weight. If multiple entries share the same group ID, only one will be picked. If an entry is the only one in its group, its guaranteed to appear. Setting this parameter to -1 will cause it to ignore exclusivity  EXAMPLE: 154",
-            "",
-            "Notes:",
+            "", "Notes:",
             "The Key Value:  For the dimension_loot_tables a key value is required, this value represents the dimensionID for the loot tables. For example, -29 is Galacticraft Mars, the loot tables under that id will only spawn in that dimension (if meteorites spawn there)",
             "The list of loot tables:  The chance of a loot table within a dimension being selected is weighted by the total weight of every entry in that loot table against every other loot tables total weights",
-            "Format:  {",
-            "      \"dimension_loot_tables\": {",
-                    "   \"0\": [   This is the start of a list of loot tables",
-                    "       [    this is the start of a loot table,",
-                    "         {",
-                    "             ENTRY",
-                    "         },",
-                    "         {",
-                    "             ANOTHER ENTRY",
-                    "         }",
-                    "       ],   this is the end of a loot table",
-                    "       [    this is the start of another separate loot table",
-                    "         {",
-                    "             ENTRY",
-                    "         },",
-                    "         {",
-                    "             ANOTHER ENTRY",
-                    "         }",
-                    "       ]    this is the end of a loot table",
-                    "    ], this is the end of the list of loot tables",
-                    "    \"-29\": [   this is the start of a list of loot tables for another dimension, and so on",
-                    "       [",
-                    "         {",
-                    " }"
-
-    };
+            "Format:  {", "      \"dimension_loot_tables\": {",
+            "   \"0\": [   This is the start of a list of loot tables",
+            "       [    this is the start of a loot table,", "         {", "             ENTRY", "         },",
+            "         {", "             ANOTHER ENTRY", "         }", "       ],   this is the end of a loot table",
+            "       [    this is the start of another separate loot table", "         {", "             ENTRY",
+            "         },", "         {", "             ANOTHER ENTRY", "         }",
+            "       ]    this is the end of a loot table", "    ], this is the end of the list of loot tables",
+            "    \"-29\": [   this is the start of a list of loot tables for another dimension, and so on", "       [",
+            "         {", " }" };
     @SerializedName("dimension_loot_tables")
     private Map<String, ArrayList<ArrayList<AEJSONEntry>>> dimension_loot_tables = new HashMap<>();
 
     private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
-
 
     public AEJSONConfig() {}
 
     public void toFile(File file) {
         try {
             FileUtils.writeStringToFile(file, GSON.toJson(instance), Charset.defaultCharset());
-        }
-        catch (Exception e) {
-            System.err.println("AE2: Could not write json config " + file.getAbsolutePath() + " | Error: Could not create JSON");
+        } catch (Exception e) {
+            System.err.println(
+                    "AE2: Could not write json config " + file.getAbsolutePath() + " | Error: Could not create JSON");
         }
     }
 
-    public AEJSONConfig fromFile(File file)
-    {
+    public AEJSONConfig fromFile(File file) {
         if (!file.exists()) {
             AEJSONConfig defaultConfig = createDefaultConfig();
             AEJSONConfig.instance = defaultConfig;
@@ -116,20 +87,41 @@ public class AEJSONConfig{
             return defaultConfig;
         }
         try {
-            AEJSONConfig loaded = GSON.fromJson(FileUtils.readFileToString(file, Charset.defaultCharset()), AEJSONConfig.class);
+            AEJSONConfig loaded = GSON
+                    .fromJson(FileUtils.readFileToString(file, Charset.defaultCharset()), AEJSONConfig.class);
             AEJSONConfig.instance = loaded;
-            return loaded;        }
-        catch (Exception e) {
-            System.err.println("AE2: Could not read json config " + file.getAbsolutePath() + " | Error: Could not pull JSON from file");
+            return loaded;
+        } catch (Exception e) {
+            System.err.println(
+                    "AE2: Could not read json config " + file.getAbsolutePath()
+                            + " | Error: Could not pull JSON from file");
             return new AEJSONConfig();
         }
     }
 
     public static AEJSONConfig createDefaultConfig() {
         AEJSONConfig config = new AEJSONConfig();
-        AEJSONEntry calcProcessorPress = new AEJSONEntry("appliedenergistics2:item.ItemMultiMaterial", 13, 1, null, 3, 1);
-        AEJSONEntry engProcessorPress = new AEJSONEntry("appliedenergistics2:item.ItemMultiMaterial", 14, 1, null, 3, 1);
-        AEJSONEntry logicProcessorPress = new AEJSONEntry("appliedenergistics2:item.ItemMultiMaterial", 15, 1, null, 3, 1);
+        AEJSONEntry calcProcessorPress = new AEJSONEntry(
+                "appliedenergistics2:item.ItemMultiMaterial",
+                13,
+                1,
+                null,
+                3,
+                1);
+        AEJSONEntry engProcessorPress = new AEJSONEntry(
+                "appliedenergistics2:item.ItemMultiMaterial",
+                14,
+                1,
+                null,
+                3,
+                1);
+        AEJSONEntry logicProcessorPress = new AEJSONEntry(
+                "appliedenergistics2:item.ItemMultiMaterial",
+                15,
+                1,
+                null,
+                3,
+                1);
         AEJSONEntry siliconPress = new AEJSONEntry("appliedenergistics2:item.ItemMultiMaterial", 19, 1, null, 3, 1);
 
         AEJSONEntry IronNugget = new AEJSONEntry("ore:nuggetIron", null, 1, 12, 3, null);
@@ -144,45 +136,112 @@ public class AEJSONConfig{
         AEJSONEntry GoldNugget = new AEJSONEntry("minecraft:gold_nugget", null, 1, 12, 3, null);
         AEJSONEntry Skystone = new AEJSONEntry("appliedenergistics2:tile.BlockSkyStone", null, null, 12, null, null);
         AEJSONEntry Diamond = new AEJSONEntry("minecraft:diamond", null, 2, 4, null, null);
-        config.dimension_loot_tables.put("0", new ArrayList<>(Arrays.asList(
-                new ArrayList<>(Arrays.asList(calcProcessorPress, CopperNugget, PlatinumNugget, IronNugget, GoldNugget, Skystone)),
-                new ArrayList<>(Arrays.asList(engProcessorPress, TinNugget, NickelNugget, IronNugget, GoldNugget, Skystone)),
-                new ArrayList<>(Arrays.asList(logicProcessorPress, SilverNugget, AluminiumNugget, IronNugget, GoldNugget, Skystone)),
-                new ArrayList<>(Arrays.asList(siliconPress, LeadNugget, ElectrumNugget, IronNugget, GoldNugget, Skystone))
-        )));
-        config.dimension_loot_tables.put("-29", new ArrayList<>(Arrays.asList(
-                new ArrayList<>(Arrays.asList(calcProcessorPress, CopperNugget, PlatinumNugget, IronNugget, GoldNugget, Skystone, Diamond)),
-                new ArrayList<>(Arrays.asList(engProcessorPress, TinNugget, NickelNugget, IronNugget, GoldNugget, Skystone, Diamond)),
-                new ArrayList<>(Arrays.asList(logicProcessorPress, SilverNugget, AluminiumNugget, IronNugget, GoldNugget, Skystone, Diamond)),
-                new ArrayList<>(Arrays.asList(siliconPress, LeadNugget, ElectrumNugget, IronNugget, GoldNugget, Skystone, Diamond))
-        )));
+        config.dimension_loot_tables.put(
+                "0",
+                new ArrayList<>(
+                        Arrays.asList(
+                                new ArrayList<>(
+                                        Arrays.asList(
+                                                calcProcessorPress,
+                                                CopperNugget,
+                                                PlatinumNugget,
+                                                IronNugget,
+                                                GoldNugget,
+                                                Skystone)),
+                                new ArrayList<>(
+                                        Arrays.asList(
+                                                engProcessorPress,
+                                                TinNugget,
+                                                NickelNugget,
+                                                IronNugget,
+                                                GoldNugget,
+                                                Skystone)),
+                                new ArrayList<>(
+                                        Arrays.asList(
+                                                logicProcessorPress,
+                                                SilverNugget,
+                                                AluminiumNugget,
+                                                IronNugget,
+                                                GoldNugget,
+                                                Skystone)),
+                                new ArrayList<>(
+                                        Arrays.asList(
+                                                siliconPress,
+                                                LeadNugget,
+                                                ElectrumNugget,
+                                                IronNugget,
+                                                GoldNugget,
+                                                Skystone)))));
+        config.dimension_loot_tables.put(
+                "-29",
+                new ArrayList<>(
+                        Arrays.asList(
+                                new ArrayList<>(
+                                        Arrays.asList(
+                                                calcProcessorPress,
+                                                CopperNugget,
+                                                PlatinumNugget,
+                                                IronNugget,
+                                                GoldNugget,
+                                                Skystone,
+                                                Diamond)),
+                                new ArrayList<>(
+                                        Arrays.asList(
+                                                engProcessorPress,
+                                                TinNugget,
+                                                NickelNugget,
+                                                IronNugget,
+                                                GoldNugget,
+                                                Skystone,
+                                                Diamond)),
+                                new ArrayList<>(
+                                        Arrays.asList(
+                                                logicProcessorPress,
+                                                SilverNugget,
+                                                AluminiumNugget,
+                                                IronNugget,
+                                                GoldNugget,
+                                                Skystone,
+                                                Diamond)),
+                                new ArrayList<>(
+                                        Arrays.asList(
+                                                siliconPress,
+                                                LeadNugget,
+                                                ElectrumNugget,
+                                                IronNugget,
+                                                GoldNugget,
+                                                Skystone,
+                                                Diamond)))));
         return config;
     }
-    private ArrayList<ArrayList<AEJSONEntry>> getTablesForDimension(int dimensionID)
-    {
-        if(DimensionManager.isDimensionRegistered(dimensionID)) {
-            if(dimension_loot_tables.containsKey(dimensionID+"")) {
-                return dimension_loot_tables.get(dimensionID+"");
-            }
-            else if (dimension_loot_tables.containsKey("0")) {
+
+    private ArrayList<ArrayList<AEJSONEntry>> getTablesForDimension(int dimensionID) {
+        if (DimensionManager.isDimensionRegistered(dimensionID)) {
+            if (dimension_loot_tables.containsKey(dimensionID + "")) {
+                return dimension_loot_tables.get(dimensionID + "");
+            } else if (dimension_loot_tables.containsKey("0")) {
                 return dimension_loot_tables.get("0");
-            }
-            else {
-                System.err.println("AE2: Configs for overworld and dimension: " + dimensionID + " are missing! | Error: Getting loot tables for dimension");
+            } else {
+                System.err.println(
+                        "AE2: Configs for overworld and dimension: " + dimensionID
+                                + " are missing! | Error: Getting loot tables for dimension");
                 return createDefaultConfig().getTablesForDimension(0);
             }
-        }
-        else {
-            System.err.println("AE2: Failure While Getting Loot Tables for Dimension: " + dimensionID + ". Using overworld configs. | Error: Dimension is not registered");
+        } else {
+            System.err.println(
+                    "AE2: Failure While Getting Loot Tables for Dimension: " + dimensionID
+                            + ". Using overworld configs. | Error: Dimension is not registered");
             return dimension_loot_tables.get("0");
         }
     }
-    public ArrayList<AEJSONEntry> getWeightedLootTable(int dimID, Random rand)
-    {
+
+    public ArrayList<AEJSONEntry> getWeightedLootTable(int dimID, Random rand) {
         ArrayList<ArrayList<AEJSONEntry>> loot_tables = instance.getTablesForDimension(dimID);
         if (loot_tables == null || loot_tables.isEmpty()) {
-            System.err.println("AE2: No loot tables found for dimension, will use default loot table" + dimID + " | Error: Empty or missing loot tables.");
-            loot_tables =  createDefaultConfig().getTablesForDimension(0);
+            System.err.println(
+                    "AE2: No loot tables found for dimension, will use default loot table" + dimID
+                            + " | Error: Empty or missing loot tables.");
+            loot_tables = createDefaultConfig().getTablesForDimension(0);
         }
         int[] totalWeights = new int[loot_tables.size()];
         int totalWeight = 0;
@@ -195,13 +254,15 @@ public class AEJSONConfig{
 
         int randomWeight = rand.nextInt(totalWeight);
         int cumulitive = 0;
-        for(int i = 0; i < totalWeights.length; i++) {
-            cumulitive+=totalWeights[i];
-            if(randomWeight <= cumulitive) {
+        for (int i = 0; i < totalWeights.length; i++) {
+            cumulitive += totalWeights[i];
+            if (randomWeight <= cumulitive) {
                 return loot_tables.get(i);
             }
         }
-        System.err.println("AE2: Failed to pull a weighted random loot_table for dimension: " + dimID + ", pulling unweighted random loot_table. | Error: Weighted random failed. THIS IS LIKELY A BUG.");
+        System.err.println(
+                "AE2: Failed to pull a weighted random loot_table for dimension: " + dimID
+                        + ", pulling unweighted random loot_table. | Error: Weighted random failed. THIS IS LIKELY A BUG.");
         return loot_tables.get(rand.nextInt(loot_tables.size()));
 
     }

--- a/src/main/java/appeng/core/AEJSONEntry.java
+++ b/src/main/java/appeng/core/AEJSONEntry.java
@@ -2,6 +2,10 @@ package appeng.core;
 
 import cpw.mods.fml.common.registry.GameRegistry;
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.oredict.OreDictionary;
+
+import java.util.Arrays;
+import java.util.List;
 import java.util.Random;
 
 public class AEJSONEntry {
@@ -30,14 +34,17 @@ public class AEJSONEntry {
         this.weight = weight;
         this.exclusiveGroupID = exclusiveGroupID;
     }
-    private ItemStack getItemStack(int amount)
+    private List<ItemStack> getItemStacks(int amount)
     {
         String[] temp = item.split(":");
-        return new ItemStack(GameRegistry.findItem(temp[0], temp[1]), amount, meta_data);
+        if(temp[0] != "ore") {
+            return Arrays.asList(new ItemStack(GameRegistry.findItem(temp[0], temp[1]), amount, meta_data));
+        }
+        return OreDictionary.getOres(temp[1]);
     }
-    public ItemStack getItemStack(Random rand)
+    public List<ItemStack> getItemStacks(Random rand)
     {
-        return getItemStack(rand.nextInt(this.max_value-min_value)+min_value);
+        return getItemStacks(rand.nextInt(this.max_value-min_value)+min_value);
     }
 
     public String toString()

--- a/src/main/java/appeng/core/AEJSONEntry.java
+++ b/src/main/java/appeng/core/AEJSONEntry.java
@@ -32,4 +32,9 @@ public class AEJSONEntry {
         this.weight = weight;
         this.exclusiveGroupID = exclusiveGroupID;
     }
+    public String toString()
+    {
+        String[] itemID = item.split(":");
+        return "Entry for " + GameRegistry.findItem(itemID[0], itemID[1]).getUnlocalizedName() + ". Meta data: " + meta_data + ". Minimum and Maximum Value: " + min_value + ", " + max_value + ". Weight and Exclusive Group ID: " + weight + ", " + exclusiveGroupID + ".";
+    }
 }

--- a/src/main/java/appeng/core/AEJSONEntry.java
+++ b/src/main/java/appeng/core/AEJSONEntry.java
@@ -1,14 +1,16 @@
 package appeng.core;
 
-import cpw.mods.fml.common.registry.GameRegistry;
+import java.util.ArrayList;
+import java.util.Random;
+
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.oredict.OreDictionary;
 
-import java.util.ArrayList;
-import java.util.Random;
+import cpw.mods.fml.common.registry.GameRegistry;
 
 public class AEJSONEntry {
+
     public String item;
     public int meta_data = 0;
     public int min_value = 0;
@@ -19,14 +21,15 @@ public class AEJSONEntry {
     /**
      * Primary constructor with optional parameters.
      *
-     * @param item              Required. Format: "modid:item" or "ore:OredictName"
-     * @param meta_data         Optional, default 0
-     * @param min_value         Optional, default 0
-     * @param max_value         Optional, default 1
-     * @param weight            Optional, default 1
-     * @param exclusiveGroupID  Optional, default -1
+     * @param item             Required. Format: "modid:item" or "ore:OredictName"
+     * @param meta_data        Optional, default 0
+     * @param min_value        Optional, default 0
+     * @param max_value        Optional, default 1
+     * @param weight           Optional, default 1
+     * @param exclusiveGroupID Optional, default -1
      */
-    public AEJSONEntry(String item, Integer meta_data, Integer min_value, Integer max_value, Integer weight, Integer exclusiveGroupID) {
+    public AEJSONEntry(String item, Integer meta_data, Integer min_value, Integer max_value, Integer weight,
+            Integer exclusiveGroupID) {
         if (item == null) {
             System.err.println("AE2: itemName is required! | Error: While loading JSON");
             throw new NullPointerException();
@@ -41,19 +44,20 @@ public class AEJSONEntry {
 
     // No-arg constructor for Gson
     public AEJSONEntry() {}
-    private ItemStack getItemStack(int amount, Random rand)
-    {
+
+    private ItemStack getItemStack(int amount, Random rand) {
         String[] temp = item.split(":");
-        if(!temp[0].equals("ore")) {
-            if(GameRegistry.findItem(temp[0], temp[1]) == null) {
-                System.err.println("AE2: NO SUCH ITEM FOUND IN REGISTRY. CONFIRM YOU ENTERED IT CORRECTLY. USING GLOWSTONE DUST | Error while loading Entry: " + this);
+        if (!temp[0].equals("ore")) {
+            if (GameRegistry.findItem(temp[0], temp[1]) == null) {
+                System.err.println(
+                        "AE2: NO SUCH ITEM FOUND IN REGISTRY. CONFIRM YOU ENTERED IT CORRECTLY. USING GLOWSTONE DUST | Error while loading Entry: "
+                                + this);
                 return new ItemStack(Items.glowstone_dust);
             }
             return new ItemStack(GameRegistry.findItem(temp[0], temp[1]), amount, meta_data);
         }
         ArrayList<ItemStack> oreDictLoot = OreDictionary.getOres(temp[1]);
-        if(oreDictLoot.size() > 0)
-        {
+        if (oreDictLoot.size() > 0) {
             ItemStack stack = oreDictLoot.get(rand.nextInt(oreDictLoot.size()));
             if (stack != null) {
                 stack = stack.copy();
@@ -61,16 +65,30 @@ public class AEJSONEntry {
                 return stack;
             }
         }
-        System.err.println("AE2: NO SUCH ORE DICTIONARY OBJECT FOUND: " + this + " USING GLOWSTONE DUST | ERROR: Getting ItemStack for Meteorite Loot");
+        System.err.println(
+                "AE2: NO SUCH ORE DICTIONARY OBJECT FOUND: " + this
+                        + " USING GLOWSTONE DUST | ERROR: Getting ItemStack for Meteorite Loot");
         return new ItemStack(Items.glowstone_dust);
     }
-    public ItemStack getItemStack(Random rand)
-    {
-        return getItemStack( ((this.max_value-min_value > 0) ? (rand.nextInt(this.max_value+1-min_value)) : 0)+min_value, rand);
+
+    public ItemStack getItemStack(Random rand) {
+        return getItemStack(
+                ((this.max_value - min_value > 0) ? (rand.nextInt(this.max_value + 1 - min_value)) : 0) + min_value,
+                rand);
     }
 
-    public String toString()
-    {
-        return "Entry for " + item + ". Meta data: " + meta_data + ". Minimum and Maximum Value: " + min_value + ", " + max_value + ". Weight and Exclusive Group ID: " + weight + ", " + exclusiveGroupID + ".";
+    public String toString() {
+        return "Entry for " + item
+                + ". Meta data: "
+                + meta_data
+                + ". Minimum and Maximum Value: "
+                + min_value
+                + ", "
+                + max_value
+                + ". Weight and Exclusive Group ID: "
+                + weight
+                + ", "
+                + exclusiveGroupID
+                + ".";
     }
 }

--- a/src/main/java/appeng/core/AEJSONEntry.java
+++ b/src/main/java/appeng/core/AEJSONEntry.java
@@ -15,32 +15,58 @@ public class AEJSONEntry {
     public int max_value = 1;
     public int weight = 1;
     public int exclusiveGroupID = -1;
-    //TODO: Replace the int with Integer to see if not including a parameter will just set it to null
-    public AEJSONEntry(String item, int meta_data, int min_value, int max_value, int weight, int exclusiveGroupID)
-    {
+
+    /**
+     * Primary constructor with optional parameters.
+     *
+     * @param item              Required. Format: "modid:item" or "ore:OredictName"
+     * @param meta_data         Optional, default 0
+     * @param min_value         Optional, default 0
+     * @param max_value         Optional, default 1
+     * @param weight            Optional, default 1
+     * @param exclusiveGroupID  Optional, default -1
+     */
+    public AEJSONEntry(String item, Integer meta_data, Integer min_value, Integer max_value, Integer weight, Integer exclusiveGroupID) {
+        if (item == null) {
+            System.err.println("AE2: itemName is required! | Error: While loading JSON");
+            throw new NullPointerException();
+        }
         this.item = item;
-        this.meta_data = meta_data;
-        this.min_value = min_value;
-        this.max_value = max_value;
-        this.weight = weight;
-        this.exclusiveGroupID = exclusiveGroupID;
+        if (meta_data != null) this.meta_data = meta_data;
+        if (min_value != null) this.min_value = min_value;
+        if (max_value != null) this.max_value = max_value;
+        if (weight != null) this.weight = weight;
+        if (exclusiveGroupID != null) this.exclusiveGroupID = exclusiveGroupID;
     }
-    private ItemStack getItemStack(int amount)
+
+    // No-arg constructor for Gson
+    public AEJSONEntry() {}
+    private ItemStack getItemStack(int amount, Random rand)
     {
         String[] temp = item.split(":");
         if(!temp[0].equals("ore")) {
+            if(GameRegistry.findItem(temp[0], temp[1]) == null) {
+                System.err.println("AE2: NO SUCH ITEM FOUND IN REGISTRY. CONFIRM YOU ENTERED IT CORRECTLY. USING GLOWSTONE DUST | Error while loading Entry: " + this);
+                return new ItemStack(Items.glowstone_dust);
+            }
             return new ItemStack(GameRegistry.findItem(temp[0], temp[1]), amount, meta_data);
         }
-        //TODO: Figure this out
-            ArrayList<ItemStack> items = OreDictionary.getOres(temp[1]);
-            if(items.size() > 0)
-                return items.get(0);
-        System.err.println("AE2: NO SUCH ORE DICTIONARY OBJECT FOUND: " + item + " | ERROR: Getting itemStack for meteorite loot");
-        return new ItemStack(Items.diamond_hoe);
+        ArrayList<ItemStack> oreDictLoot = OreDictionary.getOres(temp[1]);
+        if(oreDictLoot.size() > 0)
+        {
+            ItemStack stack = oreDictLoot.get(rand.nextInt(oreDictLoot.size()));
+            if (stack != null) {
+                stack = stack.copy();
+                stack.stackSize = amount;
+                return stack;
+            }
+        }
+        System.err.println("AE2: NO SUCH ORE DICTIONARY OBJECT FOUND: " + this + " USING GLOWSTONE DUST | ERROR: Getting ItemStack for Meteorite Loot");
+        return new ItemStack(Items.glowstone_dust);
     }
     public ItemStack getItemStack(Random rand)
     {
-        return getItemStack(rand.nextInt(this.max_value-min_value)+min_value);
+        return getItemStack( ((this.max_value-min_value > 0) ? (rand.nextInt(this.max_value+1-min_value)) : 0)+min_value, rand);
     }
 
     public String toString()

--- a/src/main/java/appeng/core/AEJSONEntry.java
+++ b/src/main/java/appeng/core/AEJSONEntry.java
@@ -1,11 +1,11 @@
 package appeng.core;
 
 import cpw.mods.fml.common.registry.GameRegistry;
+import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.oredict.OreDictionary;
 
-import java.util.Arrays;
-import java.util.List;
+import java.util.ArrayList;
 import java.util.Random;
 
 public class AEJSONEntry {
@@ -15,16 +15,7 @@ public class AEJSONEntry {
     public int max_value = 1;
     public int weight = 1;
     public int exclusiveGroupID = -1;
-
-    public AEJSONEntry(String dimensionID, String item, int meta_data, int min_value, int max_value, int weight, int exclusiveGroupID)
-    {
-        this.item = item;
-        this.meta_data = meta_data;
-        this.min_value = min_value;
-        this.max_value = max_value;
-        this.weight = weight;
-        this.exclusiveGroupID = exclusiveGroupID;
-    }
+    //TODO: Replace the int with Integer to see if not including a parameter will just set it to null
     public AEJSONEntry(String item, int meta_data, int min_value, int max_value, int weight, int exclusiveGroupID)
     {
         this.item = item;
@@ -34,22 +25,26 @@ public class AEJSONEntry {
         this.weight = weight;
         this.exclusiveGroupID = exclusiveGroupID;
     }
-    private List<ItemStack> getItemStacks(int amount)
+    private ItemStack getItemStack(int amount)
     {
         String[] temp = item.split(":");
-        if(temp[0] != "ore") {
-            return Arrays.asList(new ItemStack(GameRegistry.findItem(temp[0], temp[1]), amount, meta_data));
+        if(!temp[0].equals("ore")) {
+            return new ItemStack(GameRegistry.findItem(temp[0], temp[1]), amount, meta_data);
         }
-        return OreDictionary.getOres(temp[1]);
+        //TODO: Figure this out
+            ArrayList<ItemStack> items = OreDictionary.getOres(temp[1]);
+            if(items.size() > 0)
+                return items.get(0);
+        System.err.println("AE2: NO SUCH ORE DICTIONARY OBJECT FOUND: " + item + " | ERROR: Getting itemStack for meteorite loot");
+        return new ItemStack(Items.diamond_hoe);
     }
-    public List<ItemStack> getItemStacks(Random rand)
+    public ItemStack getItemStack(Random rand)
     {
-        return getItemStacks(rand.nextInt(this.max_value-min_value)+min_value);
+        return getItemStack(rand.nextInt(this.max_value-min_value)+min_value);
     }
 
     public String toString()
     {
-        String[] itemID = item.split(":");
-        return "Entry for " + GameRegistry.findItem(itemID[0], itemID[1]).getUnlocalizedName() + ". Meta data: " + meta_data + ". Minimum and Maximum Value: " + min_value + ", " + max_value + ". Weight and Exclusive Group ID: " + weight + ", " + exclusiveGroupID + ".";
+        return "Entry for " + item + ". Meta data: " + meta_data + ". Minimum and Maximum Value: " + min_value + ", " + max_value + ". Weight and Exclusive Group ID: " + weight + ", " + exclusiveGroupID + ".";
     }
 }

--- a/src/main/java/appeng/core/AEJSONEntry.java
+++ b/src/main/java/appeng/core/AEJSONEntry.java
@@ -1,21 +1,10 @@
 package appeng.core;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonDeserializer;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParseException;
 import cpw.mods.fml.common.registry.GameRegistry;
-import net.minecraft.item.Item;
-
-import java.lang.reflect.Type;
+import net.minecraft.item.ItemStack;
+import java.util.Random;
 
 public class AEJSONEntry {
-
-
-
     public String item;
     public int meta_data = 0;
     public int min_value = 0;
@@ -23,6 +12,15 @@ public class AEJSONEntry {
     public int weight = 1;
     public int exclusiveGroupID = -1;
 
+    public AEJSONEntry(String dimensionID, String item, int meta_data, int min_value, int max_value, int weight, int exclusiveGroupID)
+    {
+        this.item = item;
+        this.meta_data = meta_data;
+        this.min_value = min_value;
+        this.max_value = max_value;
+        this.weight = weight;
+        this.exclusiveGroupID = exclusiveGroupID;
+    }
     public AEJSONEntry(String item, int meta_data, int min_value, int max_value, int weight, int exclusiveGroupID)
     {
         this.item = item;
@@ -32,6 +30,16 @@ public class AEJSONEntry {
         this.weight = weight;
         this.exclusiveGroupID = exclusiveGroupID;
     }
+    private ItemStack getItemStack(int amount)
+    {
+        String[] temp = item.split(":");
+        return new ItemStack(GameRegistry.findItem(temp[0], temp[1]), amount, meta_data);
+    }
+    public ItemStack getItemStack(Random rand)
+    {
+        return getItemStack(rand.nextInt(this.max_value-min_value)+min_value);
+    }
+
     public String toString()
     {
         String[] itemID = item.split(":");

--- a/src/main/java/appeng/core/AppEng.java
+++ b/src/main/java/appeng/core/AppEng.java
@@ -132,7 +132,7 @@ public final class AppEng {
         final Configuration recipeConfiguration = new Configuration(recipeFile);
 
         AEConfig.instance = new AEConfig(configFile);
-        AEJSONConfig aejsonConfig = AEJSONConfig.fromFile(jsonConfigFIle);
+        AEJSONConfig.instance = new AEJSONConfig(jsonConfigFIle);
         FacadeConfig.instance = new FacadeConfig(facadeFile);
         this.customRecipeConfig = new CustomRecipeForgeConfiguration(recipeConfiguration);
         this.exportConfig = new ForgeExportConfig(recipeConfiguration);

--- a/src/main/java/appeng/core/AppEng.java
+++ b/src/main/java/appeng/core/AppEng.java
@@ -126,13 +126,14 @@ public final class AppEng {
         this.recipeDirectory = new File(this.configDirectory, "recipes");
 
         final File configFile = new File(this.configDirectory, "AppliedEnergistics2.cfg");
-        final File jsonConfigFIle = new File(this.configDirectory, "MeteoriteLootTable.json");
+        final File jsonConfigFile = new File(this.configDirectory, "MeteoriteLootTable.json");
         final File facadeFile = new File(this.configDirectory, "Facades.cfg");
         final File recipeFile = new File(this.configDirectory, "CustomRecipes.cfg");
         final Configuration recipeConfiguration = new Configuration(recipeFile);
 
         AEConfig.instance = new AEConfig(configFile);
-        AEJSONConfig.instance = new AEJSONConfig(jsonConfigFIle);
+        AEJSONConfig.instance = new AEJSONConfig();
+        AEJSONConfig.instance.fromFile(jsonConfigFile);
         FacadeConfig.instance = new FacadeConfig(facadeFile);
         this.customRecipeConfig = new CustomRecipeForgeConfiguration(recipeConfiguration);
         this.exportConfig = new ForgeExportConfig(recipeConfiguration);

--- a/src/main/java/appeng/worldgen/MeteoritePlacer.java
+++ b/src/main/java/appeng/worldgen/MeteoritePlacer.java
@@ -18,8 +18,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Random;
 
-import appeng.core.AEJSONConfig;
-import appeng.core.AEJSONEntry;
 import net.minecraft.block.Block;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.item.EntityItem;
@@ -35,6 +33,8 @@ import appeng.api.AEApi;
 import appeng.api.definitions.IBlockDefinition;
 import appeng.api.definitions.IBlocks;
 import appeng.core.AEConfig;
+import appeng.core.AEJSONConfig;
+import appeng.core.AEJSONEntry;
 import appeng.core.features.AEFeature;
 import appeng.core.worlddata.WorldData;
 import appeng.util.InventoryAdaptor;
@@ -48,7 +48,6 @@ import appeng.worldgen.meteorite.MeteoriteBlockPutter;
 import cpw.mods.fml.common.registry.GameRegistry;
 
 public final class MeteoritePlacer {
-
 
     private static final long SEED_OFFSET_CHEST_LOOT = 1;
     private static final long SEED_OFFSET_DECAY = 2;
@@ -327,10 +326,11 @@ public final class MeteoritePlacer {
                     InventoryAdaptor ap = InventoryAdaptor.getAdaptor(te, ForgeDirection.UP);
 
                     int dimID = w.getWorld().provider.dimensionId;
-                    ArrayList<AEJSONEntry> loot_table = new ArrayList<>(AEJSONConfig.instance.getWeightedLootTable(dimID, lootRng));
+                    ArrayList<AEJSONEntry> loot_table = new ArrayList<>(
+                            AEJSONConfig.instance.getWeightedLootTable(dimID, lootRng));
                     Map<Integer, ArrayList<AEJSONEntry>> exlcusion_table_map = new HashMap<>();
 
-                    int totalNormalWeight = 0; //Non-exclusive entries
+                    int totalNormalWeight = 0; // Non-exclusive entries
                     for (AEJSONEntry entry : loot_table) {
                         if (entry.exclusiveGroupID == -1) {
                             totalNormalWeight += entry.weight;
@@ -381,17 +381,21 @@ public final class MeteoritePlacer {
                     for (ItemStack items : loot) {
                         if (items != null) {
                             ap.addItems(items.copy());
-                        } else
-                            System.err.println("AE2: Item is null! | Error: Failed while adding item to loot chest in meteoritePlacer");
+                        } else System.err.println(
+                                "AE2: Item is null! | Error: Failed while adding item to loot chest in meteoritePlacer");
                     }
-                }
-                catch (Exception e)
-                {
-                    System.err.println("AE2: An unexpected error occurred! Check your JSON or report if issue is persistent! | Error: Runtime error while loading loot for meteorite. Printing info: \n" +
-                            "Stack Trace: " + Arrays.toString(e.getStackTrace()) + "\n" +
-                            "Stack Message: " + e.getMessage() + "\n" +
-                            "Class: " + e.getClass() + "\n"
-                    );
+                } catch (Exception e) {
+                    System.err.println(
+                            "AE2: An unexpected error occurred! Check your JSON or report if issue is persistent! | Error: Runtime error while loading loot for meteorite. Printing info: \n"
+                                    + "Stack Trace: "
+                                    + Arrays.toString(e.getStackTrace())
+                                    + "\n"
+                                    + "Stack Message: "
+                                    + e.getMessage()
+                                    + "\n"
+                                    + "Class: "
+                                    + e.getClass()
+                                    + "\n");
                 }
             }
         }

--- a/src/main/java/appeng/worldgen/MeteoritePlacer.java
+++ b/src/main/java/appeng/worldgen/MeteoritePlacer.java
@@ -17,6 +17,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
 
+import appeng.core.AEJSONConfig;
 import net.minecraft.block.Block;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.item.EntityItem;
@@ -382,6 +383,7 @@ public final class MeteoritePlacer {
                         // Add nothing
                     }
                 }
+                System.out.println("AE2: JSON CONFIG FOR DIM: 0 | " + AEJSONConfig.instance.getEntriesForDimension("0").toString());
                 /*-------------------CONFIG JSON FORMAT-------------------*//*
                 {
                     "map": {

--- a/src/main/java/appeng/worldgen/MeteoritePlacer.java
+++ b/src/main/java/appeng/worldgen/MeteoritePlacer.java
@@ -395,7 +395,6 @@ public final class MeteoritePlacer {
 
                 final int dimID = w.getWorld().provider.dimensionId;
                 final List<AEJSONEntry> loot_table = AEJSONConfig.instance.getWeightedLootTable(dimID, lootRng);
-                //TODO: Check that switching dimensions in game doesn't break anything
                 final Map<Integer, List<AEJSONEntry>> exlcusion_table_map = new HashMap<>();
 
                 int totalWeight = 0;
@@ -412,7 +411,7 @@ public final class MeteoritePlacer {
                         if(entry.exclusiveGroupID == -1) {
                             curWeight += entry.weight;
                             if (randWeight < curWeight) {
-                                loot.add(entry.getItemStack(lootRng));
+                                loot.addAll(entry.getItemStacks(lootRng));
                             }
                         }
                         else {
@@ -436,7 +435,7 @@ public final class MeteoritePlacer {
                             for (AEJSONEntry entry : exlcusion_table_map.get(key)) {
                                 curWeight += entry.weight;
                                 if (randWeight < curWeight) {
-                                    loot.add(entry.getItemStack(lootRng));
+                                    loot.addAll(entry.getItemStacks(lootRng));
                                     break;
                                 }
                             }
@@ -444,7 +443,7 @@ public final class MeteoritePlacer {
                         else {
                             AEJSONEntry entry = exlcusion_table_map.get(key).get(0);
                             if(entry.weight > 0) {
-                                loot.add(entry.getItemStack(lootRng));
+                                loot.addAll(entry.getItemStacks(lootRng));
                             }
                         }
                     }


### PR DESCRIPTION
- No more manual deserialization on JSON creation.
   - Switched to the instance variable for certain methods.
- Moved to a 2d arraylist object based Entry Map:
  -  Allows for multiple unique loot tables in one dimension.(is essentially the opposite of an exclusive group)
  -  Reworked all methods to support the 2d array.
  -  Removed unnessecary methods.
  -  Loot tables are selected based on total entry weight.
- Cleaned up AEJSONEntry.java
  -  Added another constructor
  - Added itemstack accessor method
- Fixed file creation on initlization event
- Completed chest loot creation in MeteoritePlacer.java
   - Removed old loot placement 
   - Added general functionality as expected from the JSON.
- Reworked defaults
- Added OreDictionary Support
- Made glowstone the base itemstack for when an entry fails to load one
- Made dimensions that are not a part of the config use the currently set overworld config rather than the default one.
- Finalized error logging
- Optimized Loot Addition
- Cleaned up error logs
- Added documentation for the JSON
- Allowed parameters to be optional
- Fixed non-inclusive stack size selection